### PR TITLE
Pre-release cleanup

### DIFF
--- a/docs/assets/asynchronics.svg
+++ b/docs/assets/asynchronics.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="800" height="800" version="1.1" viewBox="0 0 800 800" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <metadata>
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <g fill="#fff">
+  <path d="m527 650v-293c0-74-45-113-121-113l-93-1e-4v-86l93 1e-4c142 0 224 70 224 190v302z"/>
+  <ellipse cx="302" cy="502" rx="145" ry="153"/>
+ </g>
+</svg>

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,12 +34,12 @@ Here's a minimal example with a simple server implementation:
 
     ---
     The user guide contains information on general usage of the interface.
-    If you're new to nexosim-py, we recommend you start here.
+    If you are new to NeXosim-py, we recommend you start here.
 
 -   [:material-code-brackets:{ .lg .middle } **API Reference**](reference/mod_root.md)
 
     ---
 
-    A detailed description of the nexosim-py API can be found here.
+    A detailed description of the NeXosim-py API can be found here.
 
 </div>

--- a/docs/stylesheets/asynchronics.css
+++ b/docs/stylesheets/asynchronics.css
@@ -1,0 +1,54 @@
+:root>* {
+    --md-primary-fg-color: #4bc1c7;
+    --md-primary-fg-color--light: #9ad6dc;
+    --md-primary-fg-color--dark: #27989d;
+    --md-accent-fg-color: #e6b82a;
+    --md-accent-fg-color--transparent: rgb(230, 184, 42, 0.1);
+}
+
+.md-typeset .admonition,
+.md-typeset details {
+    border-width: 0;
+    border-left-width: 4px;
+}
+
+[dir=ltr] .md-typeset .admonition-title,
+[dir=ltr] .md-typeset summary {
+    border-top-left-radius: 0;
+}
+
+.md-typeset .note>.admonition-title,
+.md-typeset .note>summary,
+.md-typeset .example>.admonition-title,
+.md-typeset .example>summary {
+    background-color: var(--md-admonition-bg-color);
+}
+
+.md-typeset .admonition.note,
+.md-typeset details.note,
+.md-typeset .admonition.example,
+.md-typeset details.example {
+    border-color: #27989d;
+}
+
+.md-typeset .note>.admonition-title:before,
+.md-typeset .note>summary:before,
+.md-typeset .example>.admonition-title:before,
+.md-typeset .example>summary:before {
+    background-color: #27989d;
+}
+
+.md-typeset .warning>.admonition-title,
+.md-typeset .warning>summary {
+    background-color: var(--md-admonition-bg-color);
+}
+
+.md-typeset .admonition.warning,
+.md-typeset details.warning {
+    border-color: #e6b82a;
+}
+
+.md-typeset .warning>.admonition-title:before,
+.md-typeset .warning>summary:before {
+    background-color: #e6b82a;
+}

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -2,15 +2,33 @@
 hide:
     - navigation
 ---
+
+## Before you start
+
+NeXosim-py provides both a [conventional API][nexosim.Simulation] and an
+[`asyncio` API][nexosim.aio.Simulation].
+
+The `asyncio` API makes it possible to concurrently advance simulation time,
+schedule events and monitor simulation outputs.
+
+Because the asynchronous API faithfully reflects the conventional API, however,
+most examples in this guide use the conventional API. An example of concurrent
+simulation management leveraging the `asyncio` API is provided in a [dedicated
+section](#asyncio-api).  
+
+
 ## Setting up the simulation
 
-The connection with the server is established through instantiation of a [`Simulation`][nexosim.Simulation] object.
+The connection with the server is established through instantiation of a
+[`Simulation`][nexosim.Simulation] object.
 
-The client can communicate with the server over either a local Unix Domain Socket or a HTTP/2 connection,
-depending on how the server is set up.
+The client can communicate with the server over either a local Unix Domain
+Socket or a HTTP/2 connection, depending on how the server is set up.
 
-To connect over a unix socket the `address` provided to the [`Simulation`][nexosim.Simulation] constructor
-should be the socket path prefixed with the `unix:` scheme. The server should be started with the `run_local` function.
+To connect over a unix socket the `address` provided to the
+[`Simulation`][nexosim.Simulation] constructor should be the socket path
+prefixed with the `unix:` scheme. The server should be started with the
+`run_local` function.
 
 === "Client"
     ```python
@@ -24,8 +42,8 @@ should be the socket path prefixed with the `unix:` scheme. The server should be
     server::run_local(bench, "/tmp/nexo");
     ```
 
-For a regular remote HTTP connection the address should omit the url scheme and the server should be started using the
-`run` function.
+For a regular remote HTTP connection the address should omit the url scheme and
+the server should be started using the `run` function.
 
 === "Client"
     ```python
@@ -41,11 +59,13 @@ For a regular remote HTTP connection the address should omit the url scheme and 
 
 ### Starting the simulation
 
-Before the server can accept requests, the simulation must be initialized using the [`start()`][nexosim.Simulation.start]
-method. Attempting to send a request before the simulation is initialized will raise a
+Before the server can accept requests, the simulation must be initialized using
+the [`start()`][nexosim.Simulation.start] method. Attempting to send a request
+before the simulation is initialized will raise a
 [`SimulationNotStartedError`][nexosim.exceptions.SimulationNotStartedError].
 
-The method accepts a configuration object as an argument that can be used by the bench initializer.
+The method accepts a configuration object as an argument that can be used by the
+bench initializer.
 
 === "Client"
     ```python
@@ -195,14 +215,18 @@ The configuration object can be any serializable type:
     }
     ```
 
-If [`start()`][nexosim.Simulation.start] is called again, the simulation is reinitialized and its previous state is lost.
+If [`start()`][nexosim.Simulation.start] is called again, the simulation is
+reinitialized and its previous state is lost.
 
 ### Opening and closing sinks
 
-The initial state of the simulation's individual sinks may be either open or closed, depending on the bench initializer.
-Closed sinks do not receive new events.
+The initial state of the simulation's individual sinks may be either open or
+closed, depending on the bench initializer. Closed sinks do not receive new
+events.
 
-The [`open_sink()`][nexosim.Simulation.open_sink] and [`close_sink()`][nexosim.Simulation.close_sink] methods can be used to control the state of individual sinks.
+The [`open_sink()`][nexosim.Simulation.open_sink] and
+[`close_sink()`][nexosim.Simulation.close_sink] methods can be used to control
+the state of individual sinks.
 
 ```python
 with Simulation("0.0.0.0:41633") as sim:
@@ -214,14 +238,16 @@ with Simulation("0.0.0.0:41633") as sim:
 
 Interacting with a running simulation for the most part involves:
 
-* broadcasting events and queries to an `EventSource` or `QuerySource` respectively,
+* broadcasting events and queries to an `EventSource` or `QuerySource`
+  respectively,
 * scheduling events to occur at a later time,
 * advancing the simulation time,
-* reading events sent by the simulation to an `EventSink` .
+* reading events sent by the simulation to an `EventSink`.
 
 ### Processing events and queries
 
-Events can be broadcast to an `EventSource` using the [`process_event()`][nexosim.Simulation.process_event] method.
+Events can be broadcast to an `EventSource` using the
+[`process_event()`][nexosim.Simulation.process_event] method.
 
 ```python
 with Simulation("0.0.0.0:41633") as sim:
@@ -229,7 +255,9 @@ with Simulation("0.0.0.0:41633") as sim:
     output = sim.process_event("my_input", 5)
 ```
 
-To broadcast a query to a QuerySource use the [`process_query()`][nexosim.Simulation.process_query] method. The type of the returned value can be set using the `reply_type` parameter.
+To broadcast a query to a QuerySource use the
+[`process_query()`][nexosim.Simulation.process_query] method. The type of the
+returned value can be set using the `reply_type` parameter.
 
 ```python
 with Simulation("0.0.0.0:41633") as sim:
@@ -240,17 +268,23 @@ with Simulation("0.0.0.0:41633") as sim:
 # Prints out:
 # ['5']
 ```
+
 !!! note
-    Both [`process_event()`][nexosim.Simulation.process_event] and [`process_query()`][nexosim.Simulation.process_query] methods
-    block until completion and do not affect the simulation time.
+    Both the [`process_event()`][nexosim.Simulation.process_event] and
+    [`process_query()`][nexosim.Simulation.process_query] methods block
+    until completion and do not affect the simulation time.
 
 ### Scheduling events
 
-Events can be scheduled for a later simulation time with the [`schedule_event()`][nexosim.Simulation.schedule_event] method.
-Use the `period` argument to schedule a periodically recurring event.
+Events can be scheduled for a later simulation time with the
+[`schedule_event()`][nexosim.Simulation.schedule_event] method. Use the `period`
+argument to schedule a periodically recurring event.
 
-If you want to be able to cancel a scheduled event, the [`schedule_event()`][nexosim.Simulation.schedule_event] method
-must be called with `with_key = True`. The event can be then cancelled using the [`cancel_event()`][nexosim.Simulation.cancel_event] method and the returned event key.
+To be able to cancel a scheduled event at a later time, the
+[`schedule_event()`][nexosim.Simulation.schedule_event] method must be called
+with `with_key = True`. The event can be then cancelled using the
+[`cancel_event()`][nexosim.Simulation.cancel_event] method and the returned
+event key.
 
 ```python
 with Simulation("0.0.0.0:41633") as sim:
@@ -259,14 +293,19 @@ with Simulation("0.0.0.0:41633") as sim:
     sim.cancel_event(event_key)
 ```
 
-The time at which an event is scheduled can be an absolute simulation time using [`MonotonicTime`][nexosim.time.MonotonicTime] or relative to the current simulation time using [`Duration`][nexosim.time.Duration]
+The time at which an event is scheduled can be an absolute simulation time using
+[`MonotonicTime`][nexosim.time.MonotonicTime] or relative to the current
+simulation time using [`Duration`][nexosim.time.Duration].
 
 ### Advancing the simulation
 
-The current time of the simulation can be retrieved using the [`time()`][nexosim.Simulation.time] method.
+The current time of the simulation can be retrieved using the
+[`time()`][nexosim.Simulation.time] method.
 
-You can advance the simulation to the time of the next scheduled events with the [`step()`][nexosim.Simulation.step] method.
-Any events scheduled for the same time are processed as well. This method blocks until all of the relevant events are processed.
+The simulation can be advanced to the time of the next scheduled events with the
+[`step()`][nexosim.Simulation.step] method. All events scheduled for the same
+time are processed as well. This method blocks until all of the relevant events
+are processed.
 
 ```python
 from nexosim import Simulation
@@ -279,11 +318,13 @@ with Simulation("0.0.0.0:41633") as sim:
     print(sim.time())  # 1970-01-01 00:00:01
 ```
 
-To advance the simulation to the specified time, processing all events scheduled up to that time, use the [`step_until()`]
-[nexosim.Simulation.step_until] method. This method blocks until all of the relevant events are processed or, if the simulation
-is synchronized with a `Clock`, until the specified simulation time is reached. The time can be an absolute simulation time
-using [`MonotonicTime`][nexosim.time.MonotonicTime] or relative to the current simulation time using
-[`Duration`][nexosim.time.Duration]
+To advance the simulation to the specified time, processing all events scheduled
+up to that time, use the [`step_until()`] [nexosim.Simulation.step_until]
+method. This method blocks until all of the relevant events are processed or, if
+the simulation is synchronized with a `Clock`, until the specified simulation
+time is reached. The time can be an absolute simulation time using
+[`MonotonicTime`][nexosim.time.MonotonicTime] or relative to the current
+simulation time using [`Duration`][nexosim.time.Duration].
 
 ```python
 from nexosim import Simulation
@@ -299,8 +340,9 @@ with Simulation("0.0.0.0:41633") as sim:
     print(sim.time()) # 1970-01-01 00:00:04
 ```
 
-The [`step_unbounded()`][nexosim.Simulation.step_unbounded] method processes all of the scheduled events
-as if by calling the [`step()`][nexosim.Simulation.step] method repeatedly. This method blocks until completed.
+The [`step_unbounded()`][nexosim.Simulation.step_unbounded] method processes all
+of the scheduled events as if by calling the [`step()`][nexosim.Simulation.step]
+method repeatedly. This method blocks until completed.
 
 ```python
 from nexosim import Simulation
@@ -314,15 +356,16 @@ with Simulation("0.0.0.0:41633") as sim:
     print(sim.time())  # 1970-01-01 00:00:03
 ```
 
-The simulation can be stopped using the [`halt()`][nexosim.Simulation.halt] method.
-After receiving a `halt` request, the simulation will be stopped on the next attempt
-by the simulator to advance simulation time.
+The simulation can be stopped using the [`halt()`][nexosim.Simulation.halt]
+method. After receiving a `halt` request, the simulation will stop at the next
+attempt by the simulator to advance simulation time.
 
-The next attempt to advance the simulation time, including currently being processed `step_until()`
-and `step_unbounded()` requests, or to process an event or query will raise a
-[`SimulationHaltedError`][nexosim.exceptions.SimulationHaltedError] and terminate the simulation.
+The next attempt to advance the simulation time, including if performed as part
+of a concurrently executing `step_until()` and `step_unbounded()` call, will
+raise a [`SimulationHaltedError`][nexosim.exceptions.SimulationHaltedError].
 
-The following is an example using the asyncio API and a simulation bench synchronized with the system clock:
+The following is an example using the asyncio API and a simulation bench
+synchronized with the system clock:
 
 === "Client"
     ```python
@@ -414,14 +457,16 @@ The following is an example using the asyncio API and a simulation bench synchro
     }
     ```
 
-In the above example the simulation is stopped after 2 seconds. After the first event is processed
-the simulation time jumps to the time of the next event, but, since the simulation is synchronized
-with a real-time clock, the simulation is stopped before the next event can be processed.
+In the above example the simulation is stopped after 2 seconds. After the first
+event is processed the simulation time jumps to the time of the next event, but,
+since the simulation is synchronized with a real-time clock, the simulation is
+stopped before the next event can be processed.
 
 ### Reading events
 
-Events sent to sinks can be read using the [`read_events()`][nexosim.Simulation.read_events] method.
-The `event_type` parameter controls the type the read event will be mapped to.
+Events sent to sinks can be read using the
+[`read_events()`][nexosim.Simulation.read_events] method. The `event_type`
+parameter controls the type the read event will be mapped to.
 
 === "Client"
     ```py
@@ -512,28 +557,33 @@ The `event_type` parameter controls the type the read event will be mapped to.
     }
     ```
 
-The `EventSink` must be [open](#opening-and-closing-sinks) to receive events from the simulation.
+The `EventSink` must be [open](#opening-and-closing-sinks) to receive events
+from the simulation.
 
 
 ## Serializable types
 
-The nexosim-py package provides a convenient API for constructing Python counterparts to rust's
-`struct` and `enum` types that can be (de)serialized as events, requests
-or replies within a [`Simulation`][nexosim.Simulation].
+The NeXosim-py package provides a convenient API for constructing Python
+counterparts to rust's `struct` and `enum` types that can be (de)serialized as
+events, requests or replies within a [`Simulation`][nexosim.Simulation].
 
-A detailed description of how to use serializable types can be found in the [types module reference][nexosim.types].
+A detailed description of how to use serializable types can be found in the
+[types module reference][nexosim.types].
 
 ## Asyncio API
 
-The [aio][nexosim.aio] module provides the asynchronous [`Simulation`][nexosim.aio.Simulation] class,
-with an interface mirroring that of the regular [`Simulation`][nexosim.Simulation] class.
-The asynchronous version can be used with `asyncio` to send requests concurrently.
+The [aio][nexosim.aio] module provides the asynchronous
+[`Simulation`][nexosim.aio.Simulation] class, with an interface mirroring that
+of the regular [`Simulation`][nexosim.Simulation] class. The asynchronous
+version can be used with `asyncio` to perform concurrent calls to the
+simulation.
 
 !!! note
-    Note that `step*` and `process*` requests are mutually blocking when using the
-    asynchronous [`Simulation`][nexosim.aio.Simulation].
+    Note that `step*` and `process*` requests are mutually blocking when using
+    the asynchronous [`Simulation`][nexosim.aio.Simulation].
 
-Here's an example usage of the aio API with concurrent requests and a simulation synchronized with the system clock:
+Here's an example usage of the aio API with concurrent requests and a simulation
+synchronized with the system clock:
 
 === "Client"
     ```python

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: Nexosim-py
+site_name: NeXosim-py
 
 repo_url: https://github.com/asynchronics/nexosim-py/
 repo_name: nexosim-py
@@ -15,6 +15,11 @@ nav:
 
 theme:
   name: "material"
+  palette:
+    primary: custom
+    accent: custom
+    scheme: slate
+  logo: assets/asynchronics.svg
   features:
     - navigation.tabs
     - navigation.tabs.sticky
@@ -23,6 +28,12 @@ theme:
     - content.code.copy
     - search.suggest
     - search.highlight
+
+extra:
+  generator: false
+
+extra_css:
+  - stylesheets/asynchronics.css
 
 plugins:
   - autorefs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,17 +1,26 @@
 [project]
-name = "nexosim-py"
+name = "NeXosim-py"
 version = "0.1.0"
-maintainers = [{ name = "Stanisław Massalski", email = "stanislaw.massalski@asynchronics.com" }]
+maintainers = [
+  { name = "Stanisław Massalski", email = "stanislaw.massalski@asynchronics.com" },
+]
 description = "A gRPC client for the NeXosim simulator"
 readme = "README.md"
 requires-python = ">=3.11"
 license = "Apache-2.0"
 classifiers = [
-    "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: Apache Software License",
-    "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3",
+  "License :: OSI Approved :: Apache Software License",
+  "Operating System :: OS Independent",
 ]
-dependencies = ["attrs>=23.1.0", "cattrs>=24.1.0", "cbor2>=5.4.6", "grpcio>=1.0.0", "protobuf>=5.29.2, <6", "typing-extensions>=4.12.2"]
+dependencies = [
+  "attrs>=23.1.0",
+  "cattrs>=24.1.0",
+  "cbor2>=5.4.6",
+  "grpcio>=1.0.0",
+  "protobuf>=5.29.2, <6",
+  "typing-extensions>=4.12.2",
+]
 
 [project.urls]
 Source = "https://github.com/asynchronics/nexosim-py"
@@ -23,10 +32,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.sdist]
-exclude = [
-  "tests/bench/target/",
-  ".vscode",
-]
+exclude = ["tests/bench/target/", ".vscode"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/nexosim"]
@@ -41,15 +47,10 @@ dependencies = [
 ]
 
 [tool.hatch.envs.tests]
-dependencies = [
-  "pytest>=8.2.0",
-  "pytest-asyncio>=0.25.3",
-]
+dependencies = ["pytest>=8.2.0", "pytest-asyncio>=0.25.3"]
 
 [tool.hatch.envs.make]
-dependencies = [
-  "grpcio-tools>=1.70.0"
-]
+dependencies = ["grpcio-tools>=1.70.0"]
 
 [tool.pyright]
 include = ["src"]
@@ -59,19 +60,12 @@ enableExperimentalFeatures = true
 [tool.ruff]
 src = ["src", "tests"]
 extend-exclude = ["src/nexosim/_proto"]
-pydocstyle.convention = "google"
+lint.pydocstyle.convention = "google"
 
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = "-ra"
-testpaths = [
-    "tests",
-    "integration",
-]
-pythonpath = [
-  "src"
-]
+testpaths = ["tests", "integration"]
+pythonpath = ["src"]
 asyncio_default_fixture_loop_scope = "function"
-markers = [
-  "slow: marks tests as slow (deselect with '-m \"not slow\"')"
-]
+markers = ["slow: marks tests as slow (deselect with '-m \"not slow\"')"]

--- a/src/nexosim/__init__.py
+++ b/src/nexosim/__init__.py
@@ -3,9 +3,7 @@
 This module defines the `Simulation` type, which acts as a front-end to a
 NeXosim gRPC simulation server.
 
-
-
-Example usage:
+!!! example "Example usage"
     === "Client"
         ```py
         from dataclasses import dataclass
@@ -21,7 +19,7 @@ Example usage:
 
         # Connect to a local server listening on the 41633 port.
         with Simulation(address='localhost:41633') as sim:
-        
+
             # Initialize the simulation.
             sim.start()
 

--- a/src/nexosim/_simulation.py
+++ b/src/nexosim/_simulation.py
@@ -79,7 +79,7 @@ class Simulation:
         self.close()
 
     def close(self) -> None:
-        """Closes the grpc channel."""
+        """Closes the gRPC channel."""
         self._channel.close()
 
     def start(self, cfg: typing.Any = None) -> None:
@@ -113,10 +113,10 @@ class Simulation:
 
     def terminate(self) -> None:
         """
-        Shuts down a simulation bench.
+        Terminates a simulation.
         """
         request = simulation_pb2.TerminateRequest()
-        reply = self._stub.Terminate(request) # type: ignore
+        reply = self._stub.Terminate(request)  # type: ignore
 
         if reply.HasField("error"):
             raise _to_error(reply.error)
@@ -234,7 +234,7 @@ class Simulation:
         """
 
         request = simulation_pb2.StepUnboundedRequest()
-        reply = self._stub.StepUnbounded(request) # type: ignore
+        reply = self._stub.StepUnbounded(request)  # type: ignore
         if reply.HasField("time"):
             return MonotonicTime(reply.time.seconds, reply.time.nanos)
 
@@ -545,7 +545,9 @@ class Simulation:
         else:
             return [cbor2_converter.loads(r, event_type) for r in reply.events]  # type: ignore
 
-    def await_event(self, sink_name: str, timeout: Duration, event_type: TypeForm[T] = object) -> T:
+    def await_event(
+        self, sink_name: str, timeout: Duration, event_type: TypeForm[T] = object
+    ) -> T:
         """Waits for the next event from an event sink.
 
         The call is blocking.
@@ -571,8 +573,10 @@ class Simulation:
                 - [`SimulationNotStartedError`][nexosim.exceptions.SimulationNotStartedError]
         """
 
-        request = simulation_pb2.AwaitEventRequest(sink_name=sink_name,
-                                                   timeout=PbDuration(seconds=timeout.secs, nanos=timeout.nanos))
+        request = simulation_pb2.AwaitEventRequest(
+            sink_name=sink_name,
+            timeout=PbDuration(seconds=timeout.secs, nanos=timeout.nanos),
+        )
         reply = self._stub.AwaitEvent(request)  # type: ignore
 
         if reply.HasField("error"):

--- a/src/nexosim/aio/__init__.py
+++ b/src/nexosim/aio/__init__.py
@@ -1,8 +1,9 @@
 """Asyncio version of the simulation API.
 
-This module defines the asynchronous version of [`Simulation`][nexosim.Simulation] class.
+This module defines an asynchronous version of the
+[`Simulation`][nexosim.Simulation] class.
 
-Example usage:
+!!! example "Example usage"
     === "Client"
         ```py
         import asyncio
@@ -20,7 +21,7 @@ Example usage:
                     await sim.step_until(Duration(5))
                 except SimulationHaltedError:
                     time = await sim.time()
-                    print(f"Simulation halted at {time}") 
+                    print(f"Simulation halted at {time}")
                     print(await sim.read_events("output"))
 
         async def halt():
@@ -31,7 +32,7 @@ Example usage:
         async def main():
             await asyncio.gather(run(), halt())
 
-        asyncio.run(main()) 
+        asyncio.run(main())
         ```
     === "Server"
         ```rust
@@ -89,6 +90,7 @@ Example usage:
         }
         ```
 """
+
 from ._simulation import Simulation
 
 __all__ = ["Simulation"]

--- a/src/nexosim/aio/_simulation.py
+++ b/src/nexosim/aio/_simulation.py
@@ -2,7 +2,7 @@ import typing
 import inspect
 
 import cbor2
-from grpc import aio # type: ignore
+from grpc import aio  # type: ignore
 from google.protobuf.timestamp_pb2 import Timestamp as PbTimestamp
 from google.protobuf.duration_pb2 import Duration as PbDuration
 
@@ -97,17 +97,17 @@ class Simulation:
                 - [`SimulationOutOfSyncError`][nexosim.exceptions.SimulationOutOfSyncError]
         """
         request = simulation_pb2.InitRequest(cfg=cbor2_converter.dumps(cfg))
-        reply = await self._stub.Init(request) # type: ignore
+        reply = await self._stub.Init(request)  # type: ignore
 
         if reply.HasField("error"):
             raise _to_error(reply.error)
 
     async def terminate(self) -> None:
         """
-        Shuts down a simulation bench.
+        Terminates a simulation.
         """
         request = simulation_pb2.TerminateRequest()
-        reply = await self._stub.Terminate(request) # type: ignore
+        reply = await self._stub.Terminate(request)  # type: ignore
 
         if reply.HasField("error"):
             raise _to_error(reply.error)
@@ -127,7 +127,7 @@ class Simulation:
                 - [`SimulationNotStartedError`][nexosim.exceptions.SimulationNotStartedError]
         """
         request = simulation_pb2.HaltRequest()
-        reply = await self._stub.Halt(request) # type: ignore
+        reply = await self._stub.Halt(request)  # type: ignore
 
         if reply.HasField("error"):
             raise _to_error(reply.error)
@@ -147,7 +147,7 @@ class Simulation:
         """
 
         request = simulation_pb2.TimeRequest()
-        reply = await self._stub.Time(request) # type: ignore
+        reply = await self._stub.Time(request)  # type: ignore
 
         if reply.HasField("time"):
             return MonotonicTime(reply.time.seconds, reply.time.nanos)
@@ -185,7 +185,7 @@ class Simulation:
         """
 
         request = simulation_pb2.StepRequest()
-        reply = await self._stub.Step(request) # type: ignore
+        reply = await self._stub.Step(request)  # type: ignore
         if reply.HasField("time"):
             return MonotonicTime(reply.time.seconds, reply.time.nanos)
 
@@ -225,7 +225,7 @@ class Simulation:
         """
 
         request = simulation_pb2.StepUnboundedRequest()
-        reply = await self._stub.StepUnbounded(request) # type: ignore
+        reply = await self._stub.StepUnbounded(request)  # type: ignore
         if reply.HasField("time"):
             return MonotonicTime(reply.time.seconds, reply.time.nanos)
 
@@ -279,7 +279,7 @@ class Simulation:
 
         request = simulation_pb2.StepUntilRequest(**kwargs)  # type: ignore
 
-        reply = await self._stub.StepUntil(request) # type: ignore
+        reply = await self._stub.StepUntil(request)  # type: ignore
         if reply.HasField("time"):
             return MonotonicTime(reply.time.seconds, reply.time.nanos)
 
@@ -379,7 +379,7 @@ class Simulation:
 
         request = simulation_pb2.ScheduleEventRequest(**kwargs)  # type: ignore
 
-        reply = await self._stub.ScheduleEvent(request) # type: ignore
+        reply = await self._stub.ScheduleEvent(request)  # type: ignore
 
         if reply.HasField("key"):
             key = EventKey()
@@ -406,7 +406,7 @@ class Simulation:
         """
 
         request = simulation_pb2.CancelEventRequest(key=key._key)  # type: ignore
-        reply = await self._stub.CancelEvent(request) # type: ignore
+        reply = await self._stub.CancelEvent(request)  # type: ignore
 
         if reply.HasField("error"):
             raise _to_error(reply.error)
@@ -443,7 +443,7 @@ class Simulation:
         request = simulation_pb2.ProcessEventRequest(
             source_name=source_name, event=cbor2_converter.dumps(event)
         )
-        reply = await self._stub.ProcessEvent(request) # type: ignore
+        reply = await self._stub.ProcessEvent(request)  # type: ignore
         if reply.HasField("error"):
             raise _to_error(reply.error)
 
@@ -492,7 +492,7 @@ class Simulation:
         request = simulation_pb2.ProcessQueryRequest(
             source_name=source_name, request=cbor2_converter.dumps(request)
         )
-        reply = await self._stub.ProcessQuery(request) # type: ignore
+        reply = await self._stub.ProcessQuery(request)  # type: ignore
 
         if reply.HasField("error"):
             raise _to_error(reply.error)
@@ -502,7 +502,9 @@ class Simulation:
         else:
             return [cbor2_converter.loads(r, reply_type) for r in reply.replies]  # type: ignore
 
-    async def read_events(self, sink_name: str, event_type: TypeForm[T] = object) -> list[T]:
+    async def read_events(
+        self, sink_name: str, event_type: TypeForm[T] = object
+    ) -> list[T]:
         """Reads all events from an event sink.
 
         Args:
@@ -527,7 +529,7 @@ class Simulation:
         """
 
         request = simulation_pb2.ReadEventsRequest(sink_name=sink_name)
-        reply = await self._stub.ReadEvents(request) # type: ignore
+        reply = await self._stub.ReadEvents(request)  # type: ignore
 
         if reply.HasField("error"):
             raise _to_error(reply.error)
@@ -537,7 +539,9 @@ class Simulation:
         else:
             return [cbor2_converter.loads(r, event_type) for r in reply.events]  # type: ignore
 
-    async def await_event(self, sink_name: str, timeout: Duration, event_type: TypeForm[T] = object) -> T:
+    async def await_event(
+        self, sink_name: str, timeout: Duration, event_type: TypeForm[T] = object
+    ) -> T:
         """Waits for the next event from an event sink.
 
         The call is blocking.
@@ -563,8 +567,10 @@ class Simulation:
                 - [`SimulationNotStartedError`][nexosim.exceptions.SimulationNotStartedError]
         """
 
-        request = simulation_pb2.AwaitEventRequest(sink_name=sink_name,
-                                                   timeout=PbDuration(seconds=timeout.secs, nanos=timeout.nanos))
+        request = simulation_pb2.AwaitEventRequest(
+            sink_name=sink_name,
+            timeout=PbDuration(seconds=timeout.secs, nanos=timeout.nanos),
+        )
         reply = await self._stub.AwaitEvent(request)  # type: ignore
 
         if reply.HasField("error"):
@@ -593,7 +599,7 @@ class Simulation:
                 - [`SimulationNotStartedError`][nexosim.exceptions.SimulationNotStartedError]
         """
         request = simulation_pb2.OpenSinkRequest(sink_name=sink_name)
-        reply = await self._stub.OpenSink(request) # type: ignore
+        reply = await self._stub.OpenSink(request)  # type: ignore
 
         if reply.HasField("error"):
             raise _to_error(reply.error)
@@ -617,7 +623,7 @@ class Simulation:
         """
 
         request = simulation_pb2.CloseSinkRequest(sink_name=sink_name)
-        reply = await self._stub.CloseSink(request) # type: ignore
+        reply = await self._stub.CloseSink(request)  # type: ignore
 
         if reply.HasField("error"):
             raise _to_error(reply.error)

--- a/src/nexosim/time.py
+++ b/src/nexosim/time.py
@@ -26,7 +26,7 @@ are supported. The `Duration` type also supports multiplication and division by
 a scalar.
 
 
-Example usage:
+!!! example "Example usage"
     Basic usage:
 
     ```py
@@ -170,11 +170,7 @@ class Duration:
 
             nanoseconds: A number of nanoseconds.
         """
-        nanos = (
-            nanoseconds
-            + 1_000 * microseconds
-            + 1_000_000 * milliseconds
-        )
+        nanos = nanoseconds + 1_000 * microseconds + 1_000_000 * milliseconds
 
         carry_secs = nanos // _NANOS_IN_SEC
         secs = seconds + minutes * 60 + hours * 3_600 + days * 86_400

--- a/src/nexosim/types.py
+++ b/src/nexosim/types.py
@@ -377,6 +377,7 @@ def tupleclass(cls: typing.Type[_T]) -> typing.Type[_T]:
     # dataclass.
     arity = len(dataclasses.fields(cls))  # type: ignore
     if arity == 1:
+
         def structure_hook(d, t):
             (ty,) = typing.get_args(t.__orig_bases__[0])  # type: ignore
 
@@ -384,6 +385,7 @@ def tupleclass(cls: typing.Type[_T]) -> typing.Type[_T]:
 
         _cbor2_converter.register_structure_hook(cls, structure_hook)
     elif arity > 1:
+
         def structure_hook(d, t):
             ty_list = typing.get_args(t.__orig_bases__[0])
             args = [_cbor2_converter.structure(di, ty) for di, ty in zip(d, ty_list)]
@@ -744,24 +746,36 @@ class TupleType16Arg(
 
 @typing.overload
 def tuple_type() -> type[TupleType0Arg]: ...
+
+
 @typing.overload
 def tuple_type(_0: type[_Arg0]) -> type[TupleType1Arg[_Arg0]]: ...
+
+
 @typing.overload
 def tuple_type(
     _0: type[_Arg0], _1: type[_Arg1]
 ) -> type[TupleType2Arg[_Arg0, _Arg1]]: ...
+
+
 @typing.overload
 def tuple_type(
     _0: type[_Arg0], _1: type[_Arg1], _2: type[_Arg2]
 ) -> TupleType3Arg[_Arg0, _Arg1, _Arg2]: ...
+
+
 @typing.overload
 def tuple_type(
     _0: type[_Arg0], _1: type[_Arg1], _2: type[_Arg2], _3: type[_Arg3]
 ) -> TupleType4Arg[_Arg0, _Arg1, _Arg2, _Arg3]: ...
+
+
 @typing.overload
 def tuple_type(
     _0: type[_Arg0], _1: type[_Arg1], _2: type[_Arg2], _3: type[_Arg3], _4: type[_Arg4]
 ) -> TupleType5Arg[_Arg0, _Arg1, _Arg2, _Arg3, _Arg4]: ...
+
+
 @typing.overload
 def tuple_type(
     _0: type[_Arg0],
@@ -771,6 +785,8 @@ def tuple_type(
     _4: type[_Arg4],
     _5: type[_Arg5],
 ) -> TupleType6Arg[_Arg0, _Arg1, _Arg2, _Arg3, _Arg4, _Arg5]: ...
+
+
 @typing.overload
 def tuple_type(
     _0: type[_Arg0],
@@ -781,6 +797,8 @@ def tuple_type(
     _5: type[_Arg5],
     _6: type[_Arg6],
 ) -> TupleType7Arg[_Arg0, _Arg1, _Arg2, _Arg3, _Arg4, _Arg5, _Arg6]: ...
+
+
 @typing.overload
 def tuple_type(
     _0: type[_Arg0],
@@ -792,6 +810,8 @@ def tuple_type(
     _6: type[_Arg6],
     _7: type[_Arg7],
 ) -> TupleType8Arg[_Arg0, _Arg1, _Arg2, _Arg3, _Arg4, _Arg5, _Arg6, _Arg7]: ...
+
+
 @typing.overload
 def tuple_type(
     _0: type[_Arg0],
@@ -804,6 +824,8 @@ def tuple_type(
     _7: type[_Arg7],
     _8: type[_Arg8],
 ) -> TupleType9Arg[_Arg0, _Arg1, _Arg2, _Arg3, _Arg4, _Arg5, _Arg6, _Arg7, _Arg8]: ...
+
+
 @typing.overload
 def tuple_type(
     _0: type[_Arg0],
@@ -819,6 +841,8 @@ def tuple_type(
 ) -> TupleType10Arg[
     _Arg0, _Arg1, _Arg2, _Arg3, _Arg4, _Arg5, _Arg6, _Arg7, _Arg8, _Arg9
 ]: ...
+
+
 @typing.overload
 def tuple_type(
     _0: type[_Arg0],
@@ -835,6 +859,8 @@ def tuple_type(
 ) -> TupleType11Arg[
     _Arg0, _Arg1, _Arg2, _Arg3, _Arg4, _Arg5, _Arg6, _Arg7, _Arg8, _Arg9, _Arg10
 ]: ...
+
+
 @typing.overload
 def tuple_type(
     _0: type[_Arg0],
@@ -852,6 +878,8 @@ def tuple_type(
 ) -> TupleType12Arg[
     _Arg0, _Arg1, _Arg2, _Arg3, _Arg4, _Arg5, _Arg6, _Arg7, _Arg8, _Arg9, _Arg10, _Arg11
 ]: ...
+
+
 @typing.overload
 def tuple_type(
     _0: type[_Arg0],
@@ -882,6 +910,8 @@ def tuple_type(
     _Arg11,
     _Arg12,
 ]: ...
+
+
 @typing.overload
 def tuple_type(
     _0: type[_Arg0],
@@ -914,6 +944,8 @@ def tuple_type(
     _Arg12,
     _Arg13,
 ]: ...
+
+
 @typing.overload
 def tuple_type(
     _0: type[_Arg0],
@@ -948,6 +980,8 @@ def tuple_type(
     _Arg13,
     _Arg14,
 ]: ...
+
+
 @typing.overload
 def tuple_type(
     _0: type[_Arg0],


### PR DESCRIPTION
Among smaller nitpicks, this commit includes:
- slightly modified example in README
- new section at top of user guide on sync vs async API
- wrap user guide at 80 cols
- custom CSS (asynchronics colors, nicer admonition styling)
- reformat files with Ruff (this should probably be checked in CI)