### PR TITLE
Remove the auto color scheme

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,28 +26,19 @@ theme:
     - search.highlight
   favicon: images/favicon-16x16.png
   palette:
-    - media: "(prefers-color-scheme)"
-      toggle:
-        icon: material/brightness-auto
-        name: Switch to light mode
-
-    - media: "(prefers-color-scheme: dark)"
-      scheme: slate
+    - scheme: slate
       primary: custom
       accent: custom
       toggle:
         icon: material/brightness-4
-        name: Switch to system preference
+        name: Switch to light mode
 
-    - media: "(prefers-color-scheme: light)"
-      scheme: default
+    - scheme: default
       primary: custom
       accent: custom
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
-
-
 
 extra:
   generator: false


### PR DESCRIPTION
Toggling between the 3 modes was a bit too confusing. Also, we would prefer the dark mode to be the default. Currently, an OS with default settings would typically display the light mode.